### PR TITLE
Move Depends to Imports; fixes warnings issue

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,19 +3,20 @@ Type: Package
 Title: Robust inference in difference-in-differences and event study designs
 Version: 0.2.1
 Depends:
-    CVXR (>= 0.99-6),
-    doParallel (>= 1.0.15),
+    R (>= 3.6.0)
+Imports:
     foreach (>= 1.4.7),
+    doParallel (>= 1.0.15),
+    CVXR (>= 0.99-6),
     latex2exp (>= 0.4.0),
     lpSolveAPI (>= 5.5.2.0-17),
     Matrix (>= 1.2-17),
     pracma (>= 2.2.5),
     purrr (>= 0.3.4),
     ROI (>= 0.3-2),
-    tidyverse (>= 1.2.1),
-    TruncatedNormal (>= 1.0),
-    R (>= 3.6.0)
-Imports:
+    tibble (>= 1.3.4),
+    dplyr (>= 0.7.4),
+    TruncatedNormal (>= 1.0)
 Author: Ashesh Rambachan
 Maintainer: Ashesh Rambachan <asheshr@g.harvard.edu>
 Description: 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: HonestDiD
 Type: Package
 Title: Robust inference in difference-in-differences and event study designs
-Version: 0.2.1
+Version: 0.2.2
 Depends:
     R (>= 3.6.0)
 Imports:

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -1,3 +1,6 @@
+importFrom(dplyr, "%>%")
+importFrom(foreach, "%dopar%")
+importFrom(foreach, "%do%")
 export(computeConditionalCS_DeltaRM)
 export(computeConditionalCS_DeltaRMB)
 export(computeConditionalCS_DeltaRMM)
@@ -17,5 +20,3 @@ export(DeltaSD_lowerBound_Mpre)
 export(DeltaSD_upperBound_Mpre)
 export(findOptimalFLCI)
 export(basisVector)
-
-

--- a/R/HonestDiD-Temp.R
+++ b/R/HonestDiD-Temp.R
@@ -38,7 +38,7 @@ createSensitivityResults <- function(betahat, sigma,
   # If Mvec is null, construct default Mvec
   if (is.null(Mvec)) {
     if (numPrePeriods == 1) {
-      Mvec = seq(from = 0, to = sigma[1, 1], length.out = 10)
+      Mvec = seq(from = 0, to = c(sigma[1, 1]), length.out = 10)
     } else {
       Mub = DeltaSD_upperBound_Mpre(betahat = betahat, sigma = sigma, numPrePeriods = numPrePeriods, alpha = 0.05)
       Mvec = seq(from = 0, to = Mub, length.out = 10)
@@ -57,16 +57,16 @@ createSensitivityResults <- function(betahat, sigma,
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
@@ -77,10 +77,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -89,10 +89,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
@@ -103,10 +103,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -115,10 +115,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
@@ -129,10 +129,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -141,10 +141,10 @@ createSensitivityResults <- function(betahat, sigma,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else{
@@ -168,16 +168,16 @@ createSensitivityResults <- function(betahat, sigma,
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+         tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                        method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+         tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                        method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
@@ -189,10 +189,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -202,10 +202,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
@@ -217,10 +217,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -230,10 +230,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
@@ -245,10 +245,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -258,10 +258,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else{
@@ -285,16 +285,16 @@ createSensitivityResults <- function(betahat, sigma,
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+         tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                        method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = 0.05)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+         tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                        method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
@@ -306,10 +306,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -319,10 +319,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
@@ -334,11 +334,11 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta,
-                 M = Mvec[m])
+         tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                        ub = max(temp$grid[temp$accept == 1]),
+                        method = "C-F",
+                        Delta = Delta,
+                        M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -348,11 +348,11 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta,
-                 M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta,
+                         M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
@@ -364,10 +364,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
         Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
@@ -377,10 +377,10 @@ createSensitivityResults <- function(betahat, sigma,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else{
@@ -398,7 +398,7 @@ constructOriginalCS <- function(betahat, sigma,
   stdError = sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
   lb = t(l_vec) %*% betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)] - qnorm(1-alpha/2)*stdError
   ub = t(l_vec) %*% betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)] + qnorm(1-alpha/2)*stdError
-  return(tibble(
+  return(tibble::tibble(
     lb = lb,
     ub = ub,
     method = "Original",
@@ -423,9 +423,9 @@ createEventStudyPlot <- function(betahat, stdErrors = NULL, sigma = NULL,
     referencePeriod = 0
   }
 
-  EventStudyPlot <- ggplot(tibble(t = c(timeVec[1:numPrePeriods], referencePeriod, timeVec[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
-                                  beta = c(betahat[1:numPrePeriods], 0, betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
-                                  se = c(stdErrors[1:numPrePeriods], NA, stdErrors[(numPrePeriods+1):(numPrePeriods+numPostPeriods)])),
+  EventStudyPlot <- ggplot(tibble::tibble(t = c(timeVec[1:numPrePeriods], referencePeriod, timeVec[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
+                                          beta = c(betahat[1:numPrePeriods], 0, betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
+                                          se = c(stdErrors[1:numPrePeriods], NA, stdErrors[(numPrePeriods+1):(numPrePeriods+numPostPeriods)])),
                            aes(x = t)) +
     geom_point(aes(y = beta), color = "red") +
     geom_errorbar(aes(ymin = beta - qnorm(1-alpha/2)*se, ymax = beta + qnorm(1-alpha/2)*se), width = 0.5, colour = "#01a2d9") +

--- a/R/arp-nonuisance.R
+++ b/R/arp-nonuisance.R
@@ -185,7 +185,7 @@
     gridLength <- 0.5 * ( c(0, diff(thetaGrid)) + c(diff(thetaGrid), 0 ) )
     return(sum(resultsGrid[, 2]*gridLength))
   } else {
-    return(tibble(grid = resultsGrid[, 1],
-                  accept = resultsGrid[,2]))
+    return(tibble::tibble(grid   = resultsGrid[, 1],
+                          accept = resultsGrid[,2]))
   }
 }

--- a/R/deltarm.R
+++ b/R/deltarm.R
@@ -141,7 +141,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -186,7 +186,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
 
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -281,7 +281,7 @@ computeConditionalCS_DeltaRM <- function(betahat, sigma, numPrePeriods, numPostP
 
   # If grid.ub, grid.lb is not specified, we set these bounds to be equal to the id set under parallel trends
   # {0} +- 20*sdTheta (i.e. [-20*sdTheta, 20*sdTheta].
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
 
@@ -312,8 +312,8 @@ computeConditionalCS_DeltaRM <- function(betahat, sigma, numPrePeriods, numPostP
   CIs_RM_minus_maxS = apply(CIs_RM_minus_allS, MARGIN = 1, FUN = max)
 
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_RM = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                 accept = pmax(CIs_RM_plus_maxS, CIs_RM_minus_maxS))
+  CI_RM = tibble::tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
+                         accept = pmax(CIs_RM_plus_maxS, CIs_RM_minus_maxS))
 
   # Compute length if returnLength == T, else return grid
   if (returnLength) {

--- a/R/deltarmb.R
+++ b/R/deltarmb.R
@@ -154,7 +154,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -202,7 +202,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
 
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -300,7 +300,7 @@ computeConditionalCS_DeltaRMB <- function(betahat, sigma, numPrePeriods, numPost
 
   # If grid.ub, grid.lb is not specified, we set these bounds to be equal to the id set under parallel trends
   # {0} +- 20*sdTheta (i.e. [-20*sdTheta, 20*sdTheta].
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
 
@@ -331,8 +331,8 @@ computeConditionalCS_DeltaRMB <- function(betahat, sigma, numPrePeriods, numPost
   CIs_RMB_minus_maxS = apply(CIs_RMB_minus_allS, MARGIN = 1, FUN = max)
 
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_RMB = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                 accept = pmax(CIs_RMB_plus_maxS, CIs_RMB_minus_maxS))
+  CI_RMB = tibble::tibble(grid   = seq(grid.lb, grid.ub, length.out = gridPoints),
+                          accept = pmax(CIs_RMB_plus_maxS, CIs_RMB_minus_maxS))
 
   # Compute length if returnLength == T, else return grid
   if (returnLength) {

--- a/R/deltarmm.R
+++ b/R/deltarmm.R
@@ -152,7 +152,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -200,7 +200,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
   
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -297,7 +297,7 @@ computeConditionalCS_DeltaRMM <- function(betahat, sigma, numPrePeriods, numPost
   
   # If grid.ub, grid.lb is not specified, we set these bounds to be equal to the id set under parallel trends
   # {0} +- 20*sdTheta (i.e. [-20*sdTheta, 20*sdTheta].
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
   
@@ -328,8 +328,8 @@ computeConditionalCS_DeltaRMM <- function(betahat, sigma, numPrePeriods, numPost
   CIs_RMM_minus_maxS = apply(CIs_RMM_minus_allS, MARGIN = 1, FUN = max)
   
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_RMM = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                 accept = pmax(CIs_RMM_plus_maxS, CIs_RMM_minus_maxS))
+  CI_RMM = tibble::tibble(grid   = seq(grid.lb, grid.ub, length.out = gridPoints),
+                          accept = pmax(CIs_RMM_plus_maxS, CIs_RMM_minus_maxS))
   
   # Compute length if returnLength == T, else return grid
   if (returnLength) {

--- a/R/deltasd.R
+++ b/R/deltasd.R
@@ -133,7 +133,7 @@ library(foreach)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -195,10 +195,10 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
 
       # compute FLCI ub and FLCI lb
       if (is.na(grid.ub)){
-        grid.ub = (t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
+        grid.ub = c(t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
       }
       if (is.na(grid.lb)){
-        grid.lb = (t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
+        grid.lb = c(t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
       }
     } else if (hybrid_flag == "LF") {
       # Compute LF CV
@@ -212,7 +212,7 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
         # Compute identified set under parallel trends
         IDset = .compute_IDset_DeltaSD(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                        l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -226,7 +226,7 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
         # Compute identified set under parallel trends
         IDset = .compute_IDset_DeltaSD(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                        l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -243,7 +243,7 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
                                 A = A_SD, d = d_SD, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                 l_vec = l_vec, alpha = alpha, returnLength = returnLength,
                                 hybrid_flag = hybrid_flag, hybrid_list = hybrid_list,
-                                grid.ub = grid.ub, grid.lb = grid.lb,
+                                grid.ub = c(grid.ub), grid.lb = c(grid.lb),
                                 gridPoints = gridPoints)
     return(CI)
   } else { # CASE: NumPostPeriods > 1
@@ -258,11 +258,11 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
       hybrid_list$flci_l = flci$optimalVec
 
       # Add vbar to flci l vector
-      vbar = Variable(NROW(A_SD))
-      obj <- Minimize( t(flci$optimalVec) %*% flci$optimalVec -
-                         2 * t(flci$optimalVec) %*% t(A_SD) %*% vbar + quad_form(x = vbar, P = A_SD %*% t(A_SD)) )
-      prob = Problem(obj)
-      result = psolve(prob)
+      vbar = CVXR::Variable(NROW(A_SD))
+      obj <- CVXR::Minimize( t(flci$optimalVec) %*% flci$optimalVec -
+                         2 * t(flci$optimalVec) %*% t(A_SD) %*% vbar + CVXR::quad_form(x = vbar, P = A_SD %*% t(A_SD)) )
+      prob = CVXR::Problem(obj)
+      result = CVXR::psolve(prob)
       hybrid_list$vbar = result$getValue(vbar)
 
       # Add objects to hybrid_list: flci half-length
@@ -270,17 +270,17 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
 
       # compute FLCI ub and FLCI lb
       if (is.na(grid.ub)){
-        grid.ub = (t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
+        grid.ub = c(t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
       }
       if (is.na(grid.lb)){
-        grid.lb = (t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
+        grid.lb = c(t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
       }
 
     } else {
       # Compute identified set under parallel trends
       IDset = .compute_IDset_DeltaSD(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                      l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-      sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+      sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
       if(is.na(grid.ub)){
         grid.ub = IDset$id.ub + 20*sdTheta
       }
@@ -295,7 +295,7 @@ computeConditionalCS_DeltaSD <- function(betahat, sigma, numPrePeriods, numPostP
                         l_vec = l_vec, alpha = alpha,
                         hybrid_flag = hybrid_flag, hybrid_list = hybrid_list,
                         returnLength = returnLength,
-                        grid.lb = grid.lb, grid.ub = grid.ub,
+                        grid.lb = c(grid.lb), grid.ub = c(grid.ub),
                         gridPoints = gridPoints, rowsForARP = rowsForARP)
     # Returns CI
     return(CI)

--- a/R/deltasdb.R
+++ b/R/deltasdb.R
@@ -116,7 +116,7 @@ library(foreach)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -185,10 +185,10 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
 
       # compute FLCI ub and FLCI lb
       if (is.na(grid.ub)){
-        grid.ub = (t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
+        grid.ub = c(t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
       }
       if (is.na(grid.lb)){
-        grid.lb = (t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
+        grid.lb = c(t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
       }
     } else if (hybrid_flag == "LF") {
       # Compute LF CV
@@ -203,7 +203,7 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
         IDset = .compute_IDset_DeltaSDB(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                         biasDirection = biasDirection,
                                         l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -218,7 +218,7 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
         IDset = .compute_IDset_DeltaSDB(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                         biasDirection = biasDirection,
                                         l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -248,11 +248,11 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
       hybrid_list$flci_l = flci$optimalVec
 
       # Add vbar to flci l vector
-      vbar = Variable(NROW(A_SDB))
-      obj <- Minimize( t(flci$optimalVec) %*% flci$optimalVec -
-                         2 * t(flci$optimalVec) %*% t(A_SDB) %*% vbar + quad_form(x = vbar, P = A_SDB %*% t(A_SDB)) )
-      prob = Problem(obj)
-      result = psolve(prob)
+      vbar = CVXR::Variable(NROW(A_SDB))
+      obj <- CVXR::Minimize( t(flci$optimalVec) %*% flci$optimalVec -
+                         2 * t(flci$optimalVec) %*% t(A_SDB) %*% vbar + CVXR::quad_form(x = vbar, P = A_SDB %*% t(A_SDB)) )
+      prob = CVXR::Problem(obj)
+      result = CVXR::psolve(prob)
       hybrid_list$vbar = result$getValue(vbar)
 
       # Add objects to hybrid_list: flci half-length
@@ -260,10 +260,10 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
 
       # compute FLCI ub and FLCI lb
       if (is.na(grid.ub)){
-        grid.ub = (t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
+        grid.ub = c(t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
       }
       if (is.na(grid.lb)){
-        grid.lb = (t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
+        grid.lb = c(t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
       }
     } else {
       # Compute ID set under parallel trends
@@ -276,7 +276,7 @@ computeConditionalCS_DeltaSDB <- function(betahat, sigma, numPrePeriods, numPost
         IDset$id.lb <- new.lb
         IDset$id.ub <- new.ub
       }
-      sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+      sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
 
       if (is.na(grid.ub)) {
         grid.ub = IDset$id.ub + 20*sdTheta

--- a/R/deltasdm.R
+++ b/R/deltasdm.R
@@ -105,7 +105,7 @@ library(foreach)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - max.results$optimum
   }
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -171,10 +171,10 @@ computeConditionalCS_DeltaSDM <- function(betahat, sigma, numPrePeriods, numPost
 
       # compute FLCI ub and FLCI lb
       if (is.na(grid.ub)){
-        grid.ub = (t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
+        grid.ub = c(t(flci$optimalVec) %*% betahat) + flci$optimalHalfLength
       }
       if (is.na(grid.lb)){
-        grid.lb = (t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
+        grid.lb = c(t(flci$optimalVec) %*% betahat) - flci$optimalHalfLength
       }
     } else if (hybrid_flag == "LF") {
       # Compute LF CV
@@ -189,7 +189,7 @@ computeConditionalCS_DeltaSDM <- function(betahat, sigma, numPrePeriods, numPost
         IDset = .compute_IDset_DeltaSDM(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                         monotonicityDirection = monotonicityDirection,
                                         l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -204,7 +204,7 @@ computeConditionalCS_DeltaSDM <- function(betahat, sigma, numPrePeriods, numPost
         IDset = .compute_IDset_DeltaSDM(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                         monotonicityDirection = monotonicityDirection,
                                         l_vec = l_vec, numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-        sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+        sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
         if(is.na(grid.ub)){
           grid.ub = IDset$id.ub + 20*sdTheta
         }
@@ -234,25 +234,25 @@ computeConditionalCS_DeltaSDM <- function(betahat, sigma, numPrePeriods, numPost
       hybrid_list$flci_l = flci$optimalVec
 
       # Add vbar to flci l vector
-      vbar = Variable(NROW(A_SDM))
-      obj <- Minimize( t(flci$optimalVec) %*% flci$optimalVec -
-                         2 * t(flci$optimalVec) %*% t(A_SDM) %*% vbar + quad_form(x = vbar, P = A_SDM %*% t(A_SDM)) )
-      prob = Problem(obj)
-      result = psolve(prob)
+      vbar = CVXR::Variable(NROW(A_SDM))
+      obj <- CVXR::Minimize( t(flci$optimalVec) %*% flci$optimalVec -
+                         2 * t(flci$optimalVec) %*% t(A_SDM) %*% vbar + CVXR::quad_form(x = vbar, P = A_SDM %*% t(A_SDM)) )
+      prob = CVXR::Problem(obj)
+      result = CVXR::psolve(prob)
       hybrid_list$vbar = result$getValue(vbar)
 
       # Add objects to hybrid_list: flci half-length
       hybrid_list$flci_halflength = flci$optimalHalfLength
 
       # compute FLCI ub and FLCI lb
-      grid.ub = (t(hybrid_list$flci_l) %*% betahat) + flci$optimalHalfLength
-      grid.lb = (t(hybrid_list$flci_l) %*% betahat) - flci$optimalHalfLength
+      grid.ub = c(t(hybrid_list$flci_l) %*% betahat) + flci$optimalHalfLength
+      grid.lb = c(t(hybrid_list$flci_l) %*% betahat) - flci$optimalHalfLength
     } else {
       # Compute ID set
       IDset = .compute_IDset_DeltaSDM(M = M, trueBeta = rep(0, numPrePeriods + numPostPeriods),
                                       monotonicityDirection = monotonicityDirection, l_vec = l_vec,
                                       numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods)
-      sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+      sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
       if (is.na(grid.ub)) {
         grid.ub = IDset$id.ub + 20*sdTheta
       }

--- a/R/deltasdrm.R
+++ b/R/deltasdrm.R
@@ -137,7 +137,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -182,7 +182,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
 
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -285,7 +285,7 @@ computeConditionalCS_DeltaSDRM <- function(betahat, sigma, numPrePeriods, numPos
 
   # Construct theta grid by computing id set under parallel trends.
   # The default sets the grid to be equal to [-20*sdTheta, 20*sdTheta]
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
 
@@ -315,8 +315,8 @@ computeConditionalCS_DeltaSDRM <- function(betahat, sigma, numPrePeriods, numPos
   CIs_SDRM_minus_maxS = apply(CIs_SDRM_minus_allS, MARGIN = 1, FUN = max)
 
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_SDRM = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                   accept = pmax(CIs_SDRM_plus_maxS, CIs_SDRM_minus_maxS))
+  CI_SDRM = tibble::tibble(grid   = seq(grid.lb, grid.ub, length.out = gridPoints),
+                           accept = pmax(CIs_SDRM_plus_maxS, CIs_SDRM_minus_maxS))
 
   # Compute length, else return grid
   if (returnLength == T) {

--- a/R/deltasdrmb.R
+++ b/R/deltasdrmb.R
@@ -149,7 +149,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -196,7 +196,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
 
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -299,7 +299,7 @@ computeConditionalCS_DeltaSDRMB <- function(betahat, sigma, numPrePeriods, numPo
 
   # Construct theta grid by computing id set under parallel trends.
   # The default sets the grid to be equal to [-20*sdTheta, 20*sdTheta]
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
 
@@ -329,8 +329,8 @@ computeConditionalCS_DeltaSDRMB <- function(betahat, sigma, numPrePeriods, numPo
   CIs_SDRMB_minus_maxS = apply(CIs_SDRMB_minus_allS, MARGIN = 1, FUN = max)
 
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_SDRMB = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                   accept = pmax(CIs_SDRMB_plus_maxS, CIs_SDRMB_minus_maxS))
+  CI_SDRMB = tibble::tibble(grid   = seq(grid.lb, grid.ub, length.out = gridPoints),
+                            accept = pmax(CIs_SDRMB_plus_maxS, CIs_SDRMB_minus_maxS))
 
   # Compute length, else return grid
   if (returnLength == T) {

--- a/R/deltasdrmm.R
+++ b/R/deltasdrmm.R
@@ -149,7 +149,7 @@ library(purrr)
     id.lb = (t(l_vec) %*% trueBeta[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]) - results.max$optimum
   }
   return(
-    tibble(id.lb = id.lb, id.ub = id.ub)
+    tibble::tibble(id.lb = id.lb, id.ub = id.ub)
   )
 }
 
@@ -196,7 +196,7 @@ library(purrr)
   id.ub = max(max(id_bounds_plus$id.ub), max(id_bounds_minus$id.ub))
 
   # Return identified set
-  return(tibble(
+  return(tibble::tibble(
     id.lb = id.lb,
     id.ub = id.ub))
 }
@@ -301,7 +301,7 @@ computeConditionalCS_DeltaSDRMM <- function(betahat, sigma, numPrePeriods, numPo
 
   # Construct theta grid by computing id set under parallel trends.
   # The default sets the grid to be equal to [-20*sdTheta, 20*sdTheta]
-  sdTheta <- sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
+  sdTheta <- c(sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec))
   if (is.na(grid.ub)) { grid.ub = 20*sdTheta }
   if (is.na(grid.lb)) { grid.lb = -20*sdTheta }
 
@@ -331,8 +331,8 @@ computeConditionalCS_DeltaSDRMM <- function(betahat, sigma, numPrePeriods, numPo
   CIs_SDRMM_minus_maxS = apply(CIs_SDRMM_minus_allS, MARGIN = 1, FUN = max)
 
   # Take the max between (+), (-) and Construct grid containing theta points and whether any CI accepted
-  CI_SDRMM = tibble(grid = seq(grid.lb, grid.ub, length.out = gridPoints),
-                   accept = pmax(CIs_SDRMM_plus_maxS, CIs_SDRMM_minus_maxS))
+  CI_SDRMM = tibble::tibble(grid   = seq(grid.lb, grid.ub, length.out = gridPoints),
+                            accept = pmax(CIs_SDRMM_plus_maxS, CIs_SDRMM_minus_maxS))
 
   # Compute length, else return grid
   if (returnLength == T) {

--- a/R/sensitivityresults.R
+++ b/R/sensitivityresults.R
@@ -32,7 +32,7 @@ createSensitivityResults <- function(betahat, sigma,
   # If Mvec is null, construct default Mvec
   if (is.null(Mvec)) {
     if (numPrePeriods == 1) {
-      Mvec = seq(from = 0, to = sqrt(sigma[1, 1]), length.out = 10)
+      Mvec = seq(from = 0, to = c(sqrt(sigma[1, 1])), length.out = 10)
     } else {
       Mub = DeltaSD_upperBound_Mpre(betahat = betahat, sigma = sigma, numPrePeriods = numPrePeriods, alpha = 0.05)
       Mvec = seq(from = 0, to = Mub, length.out = 10)
@@ -47,98 +47,98 @@ createSensitivityResults <- function(betahat, sigma,
 
     if (method == "FLCI") { # If method = FLCI, construct FLCIs
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSD(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                               hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = "DeltaSD", M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = "DeltaSD", M = Mvec[m])
         }
       }
     } else{
@@ -158,104 +158,104 @@ createSensitivityResults <- function(betahat, sigma,
     if (method == "FLCI") {
       warning("You specified a sign restriction but method = FLCI. The FLCI does not use the sign restriction!")
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
       if (parallel == TRUE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
       if (parallel == TRUE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
       if (parallel == TRUE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                biasDirection = biasDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else{
@@ -275,106 +275,106 @@ createSensitivityResults <- function(betahat, sigma,
     if (method == "FLCI") {
       warning("You specified a shape restriction but method = FLCI. The FLCI does not use the shape restriction!")
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = findOptimalFLCI(betahat = betahat, sigma = sigma,
                                  numPrePeriods = numPrePeriods, numPostPeriods = numPostPeriods,
                                  l_vec = l_vec, M = Mvec[m], alpha = alpha)
-          tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
-                 method = "FLCI", Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = temp$FLCI[1], ub = temp$FLCI[2],
+                         method = "FLCI", Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "Conditional") { # If method = Conditional, construct conditional confidence intervals
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "ARP")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "Conditional",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "Conditional",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else if (method == "C-F") { # If method = C-F, construct conditional FLCI,
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta,
-                 M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta,
+                         M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "FLCI")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-F",
-                 Delta = Delta,
-                 M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-F",
+                         Delta = Delta,
+                         M = Mvec[m])
         }
       }
     } else if (method == "C-LF") {
       if (parallel == FALSE) {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
                                                l_vec = l_vec, alpha = alpha, M = Mvec[m],
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = "LF")
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = "C-LF",
-                 Delta = Delta, M = Mvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = "C-LF",
+                         Delta = Delta, M = Mvec[m])
         }
       }
     } else{
@@ -390,10 +390,10 @@ createSensitivityPlot <- function(robustResults, originalResults, rescaleFactor 
   Mmin <- min( robustResults$M)
 
   originalResults$M <- Mmin - Mgap
-  df <- bind_rows(originalResults, robustResults)
+  df <- dplyr::bind_rows(originalResults, robustResults)
 
   # Rescale all the units by rescaleFactor
-  df <- df %>% mutate_at( c("M", "ub", "lb"), ~ .x * rescaleFactor)
+  df <- df %>% dplyr::mutate_at( c("M", "ub", "lb"), ~ .x * rescaleFactor)
 
   # Filter out observations above maxM (after rescaling)
   df <- df %>% dplyr::filter(M <= maxM)
@@ -457,30 +457,30 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       Delta = "DeltaRM"
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaRM(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, Mbar = Mbarvec[m],
                                               hybrid_flag = hybrid_flag,
                                               gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaRM(betahat = betahat, sigma = sigma,
                                               numPrePeriods = numPrePeriods,
                                               numPostPeriods = numPostPeriods,
                                               l_vec = l_vec, alpha = alpha, Mbar = Mbarvec[m],
                                               hybrid_flag = hybrid_flag,
                                               gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     } else if (!is.null(monotonicityDirection)) { # if monotonicityDirection specified, Delta^{RMM}.
@@ -493,7 +493,7 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       }
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaRMM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
@@ -501,13 +501,13 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = hybrid_flag,
                                                gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaRMM(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
@@ -515,10 +515,10 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                monotonicityDirection = monotonicityDirection,
                                                hybrid_flag = hybrid_flag,
                                                gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     } else { # if biasDirection is specified, DeltaRMB.
@@ -531,7 +531,7 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       }
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaRMB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
@@ -539,13 +539,13 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                biasDirection = biasDirection,
                                                hybrid_flag = hybrid_flag,
                                                gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaRMB(betahat = betahat, sigma = sigma,
                                                numPrePeriods = numPrePeriods,
                                                numPostPeriods = numPostPeriods,
@@ -553,10 +553,10 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                biasDirection = biasDirection,
                                                hybrid_flag = hybrid_flag,
                                                gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     }
@@ -574,30 +574,30 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       Delta = "DeltaSDRM"
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDRM(betahat = betahat, sigma = sigma,
                                                 numPrePeriods = numPrePeriods,
                                                 numPostPeriods = numPostPeriods,
                                                 l_vec = l_vec, alpha = alpha, Mbar = Mbarvec[m],
                                                 hybrid_flag = hybrid_flag,
                                                 gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDRM(betahat = betahat, sigma = sigma,
                                                 numPrePeriods = numPrePeriods,
                                                 numPostPeriods = numPostPeriods,
                                                 l_vec = l_vec, alpha = alpha, Mbar = Mbarvec[m],
                                                 hybrid_flag = hybrid_flag,
                                                 gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     } else if (!is.null(monotonicityDirection)) { # if monotonicityDirection specified, Delta^{SDRMM}.
@@ -610,7 +610,7 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       }
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDRMM(betahat = betahat, sigma = sigma,
                                                  numPrePeriods = numPrePeriods,
                                                  numPostPeriods = numPostPeriods,
@@ -618,13 +618,13 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                  monotonicityDirection = monotonicityDirection,
                                                  hybrid_flag = hybrid_flag,
                                                  gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDRMM(betahat = betahat, sigma = sigma,
                                                  numPrePeriods = numPrePeriods,
                                                  numPostPeriods = numPostPeriods,
@@ -632,10 +632,10 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                  monotonicityDirection = monotonicityDirection,
                                                  hybrid_flag = hybrid_flag,
                                                  gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     } else { # if biasDirection is specified, DeltaRMB.
@@ -648,7 +648,7 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
       }
 
       if (parallel) {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %do% {
           temp = computeConditionalCS_DeltaSDRMB(betahat = betahat, sigma = sigma,
                                                  numPrePeriods = numPrePeriods,
                                                  numPostPeriods = numPostPeriods,
@@ -656,13 +656,13 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                  biasDirection = biasDirection,
                                                  hybrid_flag = hybrid_flag,
                                                  gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       } else {
-        Results = foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
+        Results = foreach::foreach(m = 1:length(Mbarvec), .combine = 'rbind') %dopar% {
           temp = computeConditionalCS_DeltaSDRMB(betahat = betahat, sigma = sigma,
                                                  numPrePeriods = numPrePeriods,
                                                  numPostPeriods = numPostPeriods,
@@ -670,10 +670,10 @@ createSensitivityResults_relativeMagnitudes <- function(betahat, sigma,
                                                  biasDirection = biasDirection,
                                                  hybrid_flag = hybrid_flag,
                                                  gridPoints = gridPoints, grid.ub = grid.ub, grid.lb = grid.lb)
-          tibble(lb = min(temp$grid[temp$accept == 1]),
-                 ub = max(temp$grid[temp$accept == 1]),
-                 method = method_named,
-                 Delta = Delta, Mbar = Mbarvec[m])
+          tibble::tibble(lb = min(temp$grid[temp$accept == 1]),
+                         ub = max(temp$grid[temp$accept == 1]),
+                         method = method_named,
+                         Delta = Delta, Mbar = Mbarvec[m])
         }
       }
     }
@@ -688,10 +688,10 @@ createSensitivityPlot_relativeMagnitudes <- function(robustResults, originalResu
   Mbarmin <- min( robustResults$Mbar)
 
   originalResults$Mbar <- Mbarmin - Mbargap
-  df <- bind_rows(originalResults, robustResults)
+  df <- dplyr::bind_rows(originalResults, robustResults)
 
   # Rescale all the units by rescaleFactor
-  df <- df %>% mutate_at( c("Mbar", "ub", "lb"), ~ .x * rescaleFactor)
+  df <- df %>% dplyr::mutate_at( c("Mbar", "ub", "lb"), ~ .x * rescaleFactor)
 
   # Filter out observations above maxM (after rescaling)
   df <- df %>% dplyr::filter(Mbar <= maxMbar)
@@ -717,7 +717,7 @@ constructOriginalCS <- function(betahat, sigma,
   stdError = sqrt(t(l_vec) %*% sigma[(numPrePeriods+1):(numPrePeriods+numPostPeriods), (numPrePeriods+1):(numPrePeriods+numPostPeriods)] %*% l_vec)
   lb = t(l_vec) %*% betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)] - qnorm(1-alpha/2)*stdError
   ub = t(l_vec) %*% betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)] + qnorm(1-alpha/2)*stdError
-  return(tibble(
+  return(tibble::tibble(
     lb = lb,
     ub = ub,
     method = "Original",
@@ -740,9 +740,9 @@ createEventStudyPlot <- function(betahat, stdErrors = NULL, sigma = NULL,
     referencePeriod = 0
   }
 
-  EventStudyPlot <- ggplot(tibble(t = c(timeVec[1:numPrePeriods], referencePeriod, timeVec[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
-                                  beta = c(betahat[1:numPrePeriods], 0, betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
-                                  se = c(stdErrors[1:numPrePeriods], NA, stdErrors[(numPrePeriods+1):(numPrePeriods+numPostPeriods)])),
+  EventStudyPlot <- ggplot(tibble::tibble(t = c(timeVec[1:numPrePeriods], referencePeriod, timeVec[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
+                                          beta = c(betahat[1:numPrePeriods], 0, betahat[(numPrePeriods+1):(numPrePeriods+numPostPeriods)]),
+                                          se = c(stdErrors[1:numPrePeriods], NA, stdErrors[(numPrePeriods+1):(numPrePeriods+numPostPeriods)])),
                            aes(x = t)) +
     geom_point(aes(y = beta), color = "red") +
     geom_errorbar(aes(ymin = beta - qnorm(1-alpha/2)*se, ymax = beta + qnorm(1-alpha/2)*se), width = 0.5, colour = "#01a2d9") +

--- a/R/ublbM_functions.R
+++ b/R/ublbM_functions.R
@@ -128,7 +128,7 @@ DeltaSD_lowerBound_Mpre <- function(betahat, sigma, numPrePeriods, alpha = 0.05,
 
   if (is.na(grid.ub)) {
     # If Mub not specified, use 3 times the max SE in the preperiod
-    grid.ub <- 3 * max(sqrt(diag(prePeriod.sigma)))
+    grid.ub <- c(3 * max(sqrt(diag(prePeriod.sigma))))
   }
   results <- .estimate_lowerBound_M_conditionalTest(prePeriod.coef = prePeriod.coef,
                                                     prePeriod.covar = prePeriod.sigma,


### PR DESCRIPTION
From #21:

- Moves all dependencies from Depends to Imports
- Makes all package calls explicit except for ggplot and related functions
- Replaces `tidyverse` with `dplyr` and `tibble`

From #6 

- `grid.lb` and `grid.ub` were occasionally set to 1x1 matrices; make them scalars to avoid the warning in `seq`. 